### PR TITLE
Replace Quest:escort:assign hook with EscortRewards:givers hook

### DIFF
--- a/hooks/load.lua
+++ b/hooks/load.lua
@@ -1,7 +1,6 @@
 -- load.lua
 
-class:bindHook("Quest:escort:assign", function(self, data)
-
+class:bindHook("EscortRewards:givers", function(self,data)
     local escortName = game.state.escort_selections[game.state.escortNum]
     if (escortName == nil) then
         -- support more than 9 escorts?
@@ -16,9 +15,9 @@ class:bindHook("Quest:escort:assign", function(self, data)
     end
     local new_types = {}
 
-    for k, escort in pairs(data.possible_types) do
-        if escort.name and escort.name == escortName then
-            new_types[#new_types + 1] = escort
+    for k, possible_escort in pairs(data.possible_types) do
+        if possible_escort.escort and possible_escort.escort.name and possible_escort.escort.name == escortName then
+            new_types[#new_types + 1] = possible_escort
             break
         end
     end

--- a/init.lua
+++ b/init.lua
@@ -4,8 +4,8 @@
 long_name = "Select your Escorts"
 short_name = "select-your-escorts" -- Determines the name of your addon's file.
 for_module = "tome"
-version = {1,6,0}
-addon_version = {2,2,0}
+version = {1,7,0}
+addon_version = {2,3,0}
 weight = 512 -- The lower this value, the sooner your addon will load compared to other addons.
 author = {'Pseudoku'}
 homepage = 'https://steamcommunity.com/id/Pseudoku/home'


### PR DESCRIPTION
Replace Quest:escort:assign hook with EscortRewards:givers hook

possible_types structure was also changed.

Fixes #1 